### PR TITLE
Add cancelled shows category via TMDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Categories:
 *  Shows with upcoming season finales within x days
 *  Returning Shows (new episodes or seasons are coming, but not within the timeframes chosen above)
 *  Ended Shows (no new episodes or seasons are expected)
+*  Cancelled Shows (series officially cancelled via TMDB API)
 
 Example overlays:
 ![Image](https://github.com/user-attachments/assets/91b08c66-58ed-417d-a87d-faf24be20896)
@@ -122,6 +123,7 @@ TV Shows:
     - file: /config/tssk/TSSK_TV_SEASON_FINALE_OVERLAYS.yml
     - file: /config/tssk/TSSK_TV_FINAL_EPISODE_OVERLAYS.yml
     - file: /config/tssk/TSSK_TV_ENDED_OVERLAYS.yml
+    - file: /config/tssk/TSSK_TV_CANCELLED_OVERLAYS.yml
     - file: /config/tssk/TSSK_TV_RETURNING_OVERLAYS.yml
   collection_files:
     - file: /config/tssk/TSSK_TV_NEW_SEASON_COLLECTION.yml
@@ -130,6 +132,7 @@ TV Shows:
     - file: /config/tssk/TSSK_TV_SEASON_FINALE_COLLECTION.yml
     - file: /config/tssk/TSSK_TV_FINAL_EPISODE_COLLECTION.yml
     - file: /config/tssk/TSSK_TV_ENDED_COLLECTION.yml
+    - file: /config/tssk/TSSK_TV_CANCELLED_COLLECTION.yml
     - file: /config/tssk/TSSK_TV_RETURNING_COLLECTION.yml
 ```
 
@@ -144,6 +147,7 @@ Rename `config.example.yml` to `config.yml` and edit the needed settings:
 
 - **sonarr_url:** Change if needed.
 - **sonarr_api_key:** Can be found in Sonarr under settings => General => Security.
+- **tmdb_api_key:** Obtain from your [TMDB](https://www.themoviedb.org/) account.
 - **skip_unmonitored:** Default `true` will skip a show if the upcoming season/episode is unmonitored.
 - **utc_offset:** Set the [UTC timezone](https://en.wikipedia.org/wiki/List_of_UTC_offsets) offset. e.g.: LA: -8, New York: -5, Amsterdam: +1, Tokyo: +9, etc
 

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -1,5 +1,6 @@
 sonarr_url: 'http://localhost:8989'
 sonarr_api_key: 'YOUR_SONARR_API_KEY'
+tmdb_api_key: 'YOUR_TMDB_API_KEY'
 
 skip_unmonitored: true
 utc_offset: +0
@@ -131,6 +132,35 @@ text_ended:
   vertical_offset: 50
   font_size: 70
   font_color: "#00ff3d"
+
+################################################################################
+##########                        CANCELLED:                        ##########
+################################################################################
+
+collection_cancelled:
+  collection_name: "Cancelled Shows"
+  smart_label: title.desc
+  sort_title: "+1_2Cancelled Shows"
+  ignore_blank_results: true
+
+backdrop_cancelled:
+  enable: false
+  back_color: "#000000"
+  back_height: 90
+  back_width: 950
+  horizontal_align: center
+  horizontal_offset: 0
+  vertical_align: bottom
+  vertical_offset: 20
+
+text_cancelled:
+  use_text: "C A N C E L L E D"
+  horizontal_align: center
+  horizontal_offset: 0
+  vertical_align: bottom
+  vertical_offset: 50
+  font_size: 70
+  font_color: "#ff0000"
 
 ################################################################################
 ##########                         RETURNING:                         ##########


### PR DESCRIPTION
## Summary
- add TMDB API support to differentiate ended and cancelled shows
- include cancelled show overlays and collections
- document TMDB API key and cancelled shows configuration
- clarify cancelled category description

## Testing
- `python -m py_compile TSSK.py`
- `python TSSK.py --help` *(fails: Config file 'config/config.yml' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68826cb008ac8331b412d4a2924b77ac