### PR TITLE
Add configurable movie history overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,25 @@ For each category, you can change the relevant settings:
 >
 >Dividers can be `/`, `-` or a space
 
+### Movie history overlay
+To display an overlay on movies based on your watch history, add `backdrop_movie_history` and `text_movie_history` blocks to your configuration.
+Both blocks accept an `enable` flag; when set to `false` the script skips generating that portion of the overlay.
+The text block also supports options like `use_text`, `font_size`, `font_color` and positioning settings. Missing values fall back to sensible defaults.
+
+```yaml
+backdrop_movie_history:
+  enable: true
+  back_color: "#000000"
+  # other backdrop settings...
+
+text_movie_history:
+  enable: true
+  use_text: "WATCHED"
+  font_size: 70
+  font_color: "#FFFFFF"
+  # other text settings...
+```
+
 ---
 ## 🚀 Usage - Running the Script
 

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -252,3 +252,26 @@ text_final_episode:
   vertical_offset: 35
   font_size: 70
   font_color: "#000000"
+################################################################################
+##########                      MOVIE HISTORY:                        ##########
+################################################################################
+
+backdrop_movie_history:
+  enable: true
+  back_color: "#000000"
+  back_height: 90
+  back_width: 950
+  horizontal_align: center
+  horizontal_offset: 0
+  vertical_align: bottom
+  vertical_offset: 20
+
+text_movie_history:
+  enable: true
+  use_text: "WATCHED"
+  horizontal_align: center
+  horizontal_offset: 0
+  vertical_align: bottom
+  vertical_offset: 35
+  font_size: 70
+  font_color: "#FFFFFF"

--- a/movies_history.py
+++ b/movies_history.py
@@ -1,0 +1,59 @@
+import os
+from copy import deepcopy
+from typing import List, Dict
+
+IS_DOCKER = os.getenv("DOCKER", "false").lower() == "true"
+
+def create_movie_overlay_yaml(output_file: str, movies: List[Dict], config_sections: Dict[str, Dict]) -> None:
+    """Create overlay YAML for movies.
+
+    Parameters
+    ----------
+    output_file : str
+        Name of the file to write to.
+    movies : list of dict
+        Each dict should at least contain a ``tmdbId`` key.
+    config_sections : dict
+        Configuration with ``backdrop`` and ``text`` subsections.
+    """
+    import yaml
+
+    output_dir = "/config/kometa/tssk/" if IS_DOCKER else "kometa/"
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.join(output_dir, output_file)
+
+    if not movies:
+        with open(output_path, "w", encoding="utf-8") as fh:
+            fh.write("#No matching movies found")
+        return
+
+    tmdb_ids = [m.get("tmdbId") for m in movies if m.get("tmdbId")]
+    overlays: Dict[str, Dict] = {}
+
+    # -- Backdrop Block --
+    backdrop_cfg = deepcopy(config_sections.get("backdrop", {}))
+    if backdrop_cfg.pop("enable", True) and tmdb_ids:
+        backdrop_cfg["name"] = "backdrop"
+        overlays["backdrop"] = {
+            "overlay": backdrop_cfg,
+            "tmdb_movie": ", ".join(str(i) for i in sorted(tmdb_ids)),
+        }
+
+    # -- Text Block --
+    text_cfg = deepcopy(config_sections.get("text", {}))
+    if text_cfg.pop("enable", True) and tmdb_ids:
+        use_text = text_cfg.pop("use_text", "WATCHED")
+        text_cfg.setdefault("font_size", 65)
+        text_cfg.setdefault("font_color", "#FFFFFF")
+        text_cfg.setdefault("horizontal_align", "center")
+        text_cfg.setdefault("horizontal_offset", 0)
+        text_cfg.setdefault("vertical_align", "bottom")
+        text_cfg.setdefault("vertical_offset", 0)
+        text_cfg["name"] = f"text({use_text})"
+        overlays["text"] = {
+            "overlay": text_cfg,
+            "tmdb_movie": ", ".join(str(i) for i in sorted(tmdb_ids)),
+        }
+
+    with open(output_path, "w", encoding="utf-8") as fh:
+        yaml.dump({"overlays": overlays}, fh, sort_keys=False)


### PR DESCRIPTION
## Summary
- add movie overlay generator that respects enable flags and default text styling
- document movie overlay options in README
- show sample movie history configuration

## Testing
- `python -m py_compile movies_history.py`


------
https://chatgpt.com/codex/tasks/task_e_68960305341c8331a40dc6c19b23a033