### PR TITLE
feat: add configurable movie overlay options

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,29 @@ For each category, you can change the relevant settings:
   - **enable:** whether or not you want a backdrop (the colored banner behind the text)
   - Change backdrop size, color and positioning. You can add any relevant variables here. [More info here](https://kometa.wiki/en/latest/files/overlays/?h=overlay#backdrop-overlay)
     
-- **text block:** 
+- **text block:**
   - **date_format:** The date format to be used on the overlays. e.g.: "yyyy-mm-dd", "mm/dd", "dd/mm", etc.
   - **capitalize_dates:** `true` will capitalize letters in dates.
   - **use_text:** Text to be used on the overlays before the date. e.h.: "NEW SEASON"
   - Change text color and positioning. You can add any relevant variables here. [More info here](https://kometa.wiki/en/latest/files/overlays/?h=overlay#text-overlay)
+  
+### Movie overlay configuration
+The movie history overlay can also be customized with two blocks:
 
+```yaml
+backdrop_movie_history:
+  enable: true   # disable to skip the colored backdrop
+  back_color: "#000000"
+  back_height: 90
+
+text_movie_history:
+  enable: true   # disable to remove text overlay
+  use_text: "TRENDING"
+  font_size: 70
+  font_color: "#FFFFFF"
+```
+
+Set `enable: false` on either block to omit that part of the overlay.
 
 >[!NOTE]
 > These are date formats you can use:<br/>

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -254,3 +254,27 @@ text_final_episode:
   vertical_offset: 35
   font_size: 70
   font_color: "#000000"
+
+################################################################################
+##########                        MOVIE HISTORY:                      ##########
+################################################################################
+
+backdrop_movie_history:
+  enable: true
+  back_color: "#000000"
+  back_height: 90
+  back_width: 950
+  horizontal_align: center
+  horizontal_offset: 0
+  vertical_align: bottom
+  vertical_offset: 20
+
+text_movie_history:
+  enable: true
+  use_text: "TRENDING"
+  horizontal_align: center
+  horizontal_offset: 0
+  vertical_align: bottom
+  vertical_offset: 35
+  font_size: 70
+  font_color: "#FFFFFF"

--- a/movies_history.py
+++ b/movies_history.py
@@ -75,23 +75,36 @@ def create_movie_overlay_yaml(output_file, movies, config_sections=None):
             f.write("#No matching movies found")
         return
     tmdb_ids = ", ".join(str(m["tmdbId"]) for m in movies if m.get("tmdbId"))
+    overlays = {}
+
+    # Backdrop block
     backdrop_config = deepcopy(config_sections.get("backdrop", {}))
-    backdrop_config.setdefault("name", "backdrop")
-    data = {
-        "overlays": {
-            "backdrop": {
-                "overlay": backdrop_config,
-                "tmdb_movie": tmdb_ids,
-            }
+    enable_backdrop = backdrop_config.pop("enable", True)
+    if enable_backdrop:
+        backdrop_config.setdefault("name", "backdrop")
+        overlays["backdrop"] = {
+            "overlay": backdrop_config,
+            "tmdb_movie": tmdb_ids,
         }
-    }
+
+    # Text block
     text_config = deepcopy(config_sections.get("text", {}))
-    if text_config:
-        text_config.setdefault("name", "text")
-        data["overlays"]["text"] = {
+    enable_text = text_config.pop("enable", True)
+    if enable_text:
+        use_text = text_config.pop("use_text", "TRENDING")
+        text_config.setdefault("horizontal_align", "center")
+        text_config.setdefault("horizontal_offset", 0)
+        text_config.setdefault("vertical_align", "bottom")
+        text_config.setdefault("vertical_offset", 35)
+        text_config.setdefault("font_size", 70)
+        text_config.setdefault("font_color", "#FFFFFF")
+        text_config["name"] = f"text({use_text})"
+        overlays["text"] = {
             "overlay": text_config,
             "tmdb_movie": tmdb_ids,
         }
+
+    data = {"overlays": overlays}
     with open(output_file, "w", encoding="utf-8") as f:
         yaml.dump(data, f, sort_keys=False)
 


### PR DESCRIPTION
## Summary
- allow movie overlay blocks to be disabled with `enable` flags
- support text overlay options for movies with sensible defaults
- document movie overlay configuration and provide example settings

## Testing
- `python -m py_compile movies_history.py`


------
https://chatgpt.com/codex/tasks/task_e_689626db207483318b1250f2e42598dd