### PR TITLE
Add configurable 'This Month in History' movie category

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,23 +182,29 @@ For each category, you can change the relevant settings:
   - **use_text:** Text to be used on the overlays before the date. e.h.: "NEW SEASON"
   - Change text color and positioning. You can add any relevant variables here. [More info here](https://kometa.wiki/en/latest/files/overlays/?h=overlay#text-overlay)
   
-### Movie overlay configuration
-The movie history overlay can also be customized with two blocks:
+### This Month in History configuration
+The This Month in History collection and overlay can be customized with three blocks:
 
 ```yaml
-backdrop_movie_history:
+collection_this_month_in_history:
+  collection_name: "This Month in History"
+  smart_label: title.desc
+  sort_title: "+1_2This Month in History"
+  ignore_blank_results: true
+
+backdrop_this_month_in_history:
   enable: true   # disable to skip the colored backdrop
   back_color: "#000000"
   back_height: 90
 
-text_movie_history:
+text_this_month_in_history:
   enable: true   # disable to remove text overlay
-  use_text: "TRENDING"
+  use_text: "THIS MONTH"
   font_size: 70
   font_color: "#FFFFFF"
 ```
 
-Set `enable: false` on either block to omit that part of the overlay.
+Set `enable: false` on the backdrop or text block to omit that part of the overlay.
 
 >[!NOTE]
 > These are date formats you can use:<br/>

--- a/TSSK.py
+++ b/TSSK.py
@@ -6,7 +6,7 @@ import sys
 import os
 from movies_history import (
     process_radarr_url,
-    get_movie_history,
+    get_this_month_in_history,
     create_movie_overlay_yaml,
     create_movie_collection_yaml,
 )
@@ -1411,18 +1411,20 @@ def main():
             "TSSK_TV_RETURNING_COLLECTION.yml", returning_shows, config
         )
 
-        # ---- Movie History ----
-        if tmdb_api_key and radarr_url and radarr_api_key:
-            movie_history = get_movie_history(tmdb_api_key, radarr_url, radarr_api_key)
+        # ---- This Month in History ----
+        if radarr_url and radarr_api_key:
+            month_history = get_this_month_in_history(radarr_url, radarr_api_key)
             create_movie_overlay_yaml(
-                "TSSK_MOVIE_HISTORY_OVERLAYS.yml",
-                movie_history,
-                {"backdrop": config.get("backdrop_movie_history", {}),
-                 "text": config.get("text_movie_history", {})},
+                "TSSK_THIS_MONTH_IN_HISTORY_OVERLAYS.yml",
+                month_history,
+                {
+                    "backdrop": config.get("backdrop_this_month_in_history", {}),
+                    "text": config.get("text_this_month_in_history", {}),
+                },
             )
             create_movie_collection_yaml(
-                "TSSK_MOVIE_HISTORY_COLLECTION.yml",
-                movie_history,
+                "TSSK_THIS_MONTH_IN_HISTORY_COLLECTION.yml",
+                month_history,
                 config,
             )
 

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -256,10 +256,16 @@ text_final_episode:
   font_color: "#000000"
 
 ################################################################################
-##########                        MOVIE HISTORY:                      ##########
+##########                  THIS MONTH IN HISTORY:                   ##########
 ################################################################################
 
-backdrop_movie_history:
+collection_this_month_in_history:
+  collection_name: "This Month in History"
+  smart_label: title.desc
+  sort_title: "+1_2This Month in History"
+  ignore_blank_results: true
+
+backdrop_this_month_in_history:
   enable: true
   back_color: "#000000"
   back_height: 90
@@ -269,9 +275,9 @@ backdrop_movie_history:
   vertical_align: bottom
   vertical_offset: 20
 
-text_movie_history:
+text_this_month_in_history:
   enable: true
-  use_text: "TRENDING"
+  use_text: "THIS MONTH"
   horizontal_align: center
   horizontal_offset: 0
   vertical_align: bottom


### PR DESCRIPTION
## Summary
- allow configuring a new "This Month in History" movie category
- support collection/overlay customization for movies released in this month of previous years
- document configuration for the new category

## Testing
- `python -m py_compile TSSK.py movies_history.py`


------
https://chatgpt.com/codex/tasks/task_e_6898c7685e5083318f405f32b58203a5