### PR TITLE
feat: allow country-specific movie release dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ For each category, you can change the relevant settings:
 ### This Month in History configuration
 The This Month in History collection and overlay can be customized with three blocks:
 
+Set `movie_release_country` in your main configuration to choose which country's release dates are checked when building this collection. Use an [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code such as `US` or `GB`.
+
 ```yaml
 collection_this_month_in_history:
   collection_name: "This Month in History"

--- a/TSSK.py
+++ b/TSSK.py
@@ -1091,6 +1091,7 @@ def main():
         tmdb_api_key = config.get("tmdb_api_key")
         radarr_url = config.get("radarr_url")
         radarr_api_key = config.get("radarr_api_key")
+        movie_release_country = config.get("movie_release_country")
         if radarr_url and radarr_api_key:
             radarr_url = process_radarr_url(radarr_url, radarr_api_key)
         else:
@@ -1413,7 +1414,9 @@ def main():
 
         # ---- This Month in History ----
         if radarr_url and radarr_api_key:
-            month_history = get_this_month_in_history(radarr_url, radarr_api_key)
+            month_history = get_this_month_in_history(
+                radarr_url, radarr_api_key, tmdb_api_key, movie_release_country
+            )
             create_movie_overlay_yaml(
                 "TSSK_THIS_MONTH_IN_HISTORY_OVERLAYS.yml",
                 month_history,

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -1,6 +1,7 @@
 sonarr_url: 'http://localhost:8989'
 sonarr_api_key: 'YOUR_SONARR_API_KEY'
 tmdb_api_key: 'YOUR_TMDB_API_KEY'
+movie_release_country: 'US'
 radarr_url: 'http://localhost:7878'
 radarr_api_key: 'YOUR_RADARR_API_KEY'
 


### PR DESCRIPTION
## Summary
- support country-specific movie release dates for This Month in History
- allow configuration of `movie_release_country`

## Testing
- `python -m py_compile movies_history.py TSSK.py`
- `python - <<'PY'
from datetime import datetime
import movies_history

now = datetime.now()
current_month = now.month
current_year = now.year

# Sample Radarr movies without fallback
radarr_movies = [
    {"title": "Match", "tmdbId": 1},
    {"title": "WrongMonth", "tmdbId": 2},
    {"title": "CurrentYear", "tmdbId": 3},
]
movies_history.get_radarr_movies = lambda url, key: radarr_movies

class Resp:
    def __init__(self, data):
        self.data = data
        self.status_code = 200
    def json(self):
        return self.data

def fake_get(url, timeout=10):
    if "/1/" in url:
        return Resp({"results": [{"iso_3166_1": "US", "release_dates": [{"release_date": f"{current_year-1}-{current_month:02d}-01T00:00:00.000Z"}]}]})
    if "/2/" in url:
        wrong_month = current_month % 12 + 1
        return Resp({"results": [{"iso_3166_1": "US", "release_dates": [{"release_date": f"{current_year-1}-{wrong_month:02d}-01T00:00:00.000Z"}]}]})
    if "/3/" in url:
        return Resp({"results": [{"iso_3166_1": "US", "release_dates": [{"release_date": f"{current_year}-{current_month:02d}-01T00:00:00.000Z"}]}]})
    return Resp({"results": []})

movies_history.requests.get = fake_get

res = movies_history.get_this_month_in_history("url", "key", "tmdb", "US")
print(res)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6899f30937248331bc889b7f50e01c0d