### PR TITLE
Add configurable In Cinema overlays and collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Example overlays:
 - ℹ️ **Informs**: Lists matched and skipped(unmonitored) TV shows.
 - 📝 **Creates .yml**: Creates collection and overlay files which can be used with Kometa.
 - 🎬 **Movie support**: Filters TMDb movie lists through Radarr so only owned titles are used.
+- 🍿 **In Cinema tracking**: Build collections and overlays for movies currently in theaters.
 
 ---
 
@@ -202,6 +203,30 @@ backdrop_this_month_in_history:
 text_this_month_in_history:
   enable: true   # disable to remove text overlay
   use_text: "THIS MONTH"
+  font_size: 70
+  font_color: "#FFFFFF"
+```
+
+Set `enable: false` on the backdrop or text block to omit that part of the overlay.
+
+### In Cinema configuration
+The In Cinema collection and overlay can be customized with three blocks:
+
+```yaml
+collection_in_cinema:
+  collection_name: "In Cinema"
+  smart_label: title.desc
+  sort_title: "+1_2In Cinema"
+  ignore_blank_results: true
+
+backdrop_in_cinema:
+  enable: true   # disable to skip the colored backdrop
+  back_color: "#000000"
+  back_height: 90
+
+text_in_cinema:
+  enable: true   # disable to remove text overlay
+  use_text: "IN CINEMA"
   font_size: 70
   font_color: "#FFFFFF"
 ```

--- a/TSSK.py
+++ b/TSSK.py
@@ -1418,6 +1418,7 @@ def main():
             month_history = get_this_month_in_history(
                 radarr_url, radarr_api_key, tmdb_api_key, movie_release_country
             )
+            month_name = datetime.now().strftime("%B")
             create_movie_overlay_yaml(
                 "TSSK_THIS_MONTH_IN_HISTORY_OVERLAYS.yml",
                 month_history,
@@ -1430,6 +1431,29 @@ def main():
                 "TSSK_THIS_MONTH_IN_HISTORY_COLLECTION.yml",
                 month_history,
                 config,
+                "collection_this_month_in_history",
+                "This Month in History",
+                f"Movies released in {month_name} in previous years",
+            )
+
+            in_theaters = get_in_theaters(
+                radarr_url, radarr_api_key, tmdb_api_key, movie_release_country
+            )
+            create_movie_overlay_yaml(
+                "TSSK_IN_CINEMA_OVERLAYS.yml",
+                in_theaters,
+                {
+                    "backdrop": config.get("backdrop_in_cinema", {}),
+                    "text": config.get("text_in_cinema", {}),
+                },
+            )
+            create_movie_collection_yaml(
+                "TSSK_IN_CINEMA_COLLECTION.yml",
+                in_theaters,
+                config,
+                "collection_in_cinema",
+                "In Cinema",
+                "Movies currently in cinemas",
             )
 
         print(f"\nAll YAML files created successfully")

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -286,3 +286,33 @@ text_this_month_in_history:
   vertical_offset: 35
   font_size: 70
   font_color: "#FFFFFF"
+
+################################################################################
+##########                         IN CINEMA:                         ##########
+################################################################################
+
+collection_in_cinema:
+  collection_name: "In Cinema"
+  smart_label: title.desc
+  sort_title: "+1_2In Cinema"
+  ignore_blank_results: true
+
+backdrop_in_cinema:
+  enable: true
+  back_color: "#000000"
+  back_height: 90
+  back_width: 950
+  horizontal_align: center
+  horizontal_offset: 0
+  vertical_align: bottom
+  vertical_offset: 20
+
+text_in_cinema:
+  enable: true
+  use_text: "IN CINEMA"
+  horizontal_align: center
+  horizontal_offset: 0
+  vertical_align: bottom
+  vertical_offset: 35
+  font_size: 70
+  font_color: "#FFFFFF"


### PR DESCRIPTION
## Summary
- generate In Cinema overlay and collection YAML files using Radarr and TMDb
- generalize movie collection builder to support multiple categories
- document new In Cinema configuration in README and config example

## Testing
- `python -m py_compile TSSK.py movies_history.py movies_in_theaters.py`


------
https://chatgpt.com/codex/tasks/task_e_689a1b0e6dac833189635ce9abf09c9a