### PR TITLE
Clarify Radarr requirement for In Cinema feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ text_this_month_in_history:
 Set `enable: false` on the backdrop or text block to omit that part of the overlay.
 
 ### In Cinema configuration
+>[!NOTE]
+> Only movies present in Radarr appear in the list.
+
 The In Cinema collection and overlay can be customized with three blocks:
 
 ```yaml

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -291,6 +291,7 @@ text_this_month_in_history:
 ##########                         IN CINEMA:                         ##########
 ################################################################################
 
+# Only movies present in Radarr appear in this list.
 collection_in_cinema:
   collection_name: "In Cinema"
   smart_label: title.desc


### PR DESCRIPTION
## Summary
- note that only Radarr movies appear in In Cinema collections
- document the same in example configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aff8c59a88331a6de15909f3021af