### PR TITLE
Add configurable GitHub release check and bump version to 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ Example overlays:
 - 🎬 **Movie support**: Filters TMDb movie lists through Radarr so only owned titles are used.
 - 🍿 **In Cinema tracking**: Build collections and overlays for movies currently in theaters.
 
+## 🔄 Version Control
+
+The script checks GitHub releases to let you know when a newer version is available. By default it
+looks for updates in the `netplexflix/TV-show-status-for-Kometa` repository. Set the
+`GITHUB_REPO` environment variable to point to your own fork if you want the script to track your
+releases instead.
+
+### Creating a Release
+
+1. Tag the commit you want to release, e.g. `git tag v2.1` and push the tag to GitHub.
+2. On GitHub, open the **Releases** section and click **Draft a new release**.
+3. Select the tag (such as `v2.1`), add release notes, and publish the release. The tag name minus
+   the leading `v` is used as the version number the script compares against.
+
+When the script runs, it will query GitHub and inform you if a newer tagged release is available.
+
 ---
 
 ## 🛠️ Installation

--- a/TSSK.py
+++ b/TSSK.py
@@ -15,7 +15,11 @@ from movies_in_theaters import get_in_theaters
 
 # Constants
 IS_DOCKER = os.getenv("DOCKER", "false").lower() == "true"
-VERSION = "1.8"
+VERSION = "2.1"
+# Repository used for version checks
+GITHUB_REPO = os.getenv(
+    "GITHUB_REPO", "netplexflix/TV-show-status-for-Kometa"
+)
 
 # ANSI color codes
 GREEN = "\033[32m"
@@ -27,11 +31,11 @@ BOLD = "\033[1m"
 
 
 def check_for_updates():
-    print(f"Checking for updates to TSSK {VERSION}...")
+    print(f"Checking for updates to TSSK {VERSION} from {GITHUB_REPO}...")
 
     try:
         response = requests.get(
-            "https://api.github.com/repos/netplexflix/TV-show-status-for-Kometa/releases/latest",
+            f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest",
             timeout=10,
         )
         response.raise_for_status()


### PR DESCRIPTION
## Summary
- allow selecting GitHub repository for update checks via `GITHUB_REPO`
- bump script version to 2.1
- document release creation and version control configuration

## Testing
- `python -m py_compile TSSK.py`
- `python -m py_compile movies_history.py movies_in_theaters.py`


------
https://chatgpt.com/codex/tasks/task_e_689b052705008331a861c6303a0649db